### PR TITLE
[NETBEANS-2437] Unit tests of php.editor fail (#1232)

### DIFF
--- a/php/php.editor/nbproject/project.properties
+++ b/php/php.editor/nbproject/project.properties
@@ -78,5 +78,5 @@ test.config.stableBTD.excludes=\
     **/ParamDeclTypes68Test.class,\
     **/SemanticAnalyzerTest.class,\
     **/ToggleBlockCommentActionTest.class
-nashorn.prepend=${basedir}/../libs.nashorn/external/nashorn-02f810c26ff9-patched.jar
-bootclasspath.prepend=${nashorn.prepend}${path.separator}${basedir}/../libs.nashorn/external/asm-all-4.0.jar
+nashorn.prepend=${basedir}/../../webcommon/libs.nashorn/external/com.oracle.js.parser-ba7a8bc42268.jar
+bootclasspath.prepend=${nashorn.prepend}

--- a/php/php.editor/nbproject/project.xml
+++ b/php/php.editor/nbproject/project.xml
@@ -474,6 +474,12 @@
                         <compile-dependency/>
                     </test-dependency>
                     <test-dependency>
+                        <code-name-base>org.netbeans.libs.nashorn</code-name-base>
+                        <recursive/>
+                        <compile-dependency/>
+                        <test/>
+                    </test-dependency>
+                    <test-dependency>
                         <code-name-base>org.netbeans.modules.csl.api</code-name-base>
                         <recursive/>
                         <compile-dependency/>

--- a/webcommon/javascript2.editor/nbproject/project.properties
+++ b/webcommon/javascript2.editor/nbproject/project.properties
@@ -29,5 +29,5 @@ extra.module.files=\
     jsstubs/reststubs.zip
 jnlp.indirect.jars=jsstubs/*.zip
 
-nashorn.prepend=${basedir}/../libs.nashorn/external/nashorn-02f810c26ff9-patched.jar
-bootclasspath.prepend=${nashorn.prepend}${path.separator}${basedir}/../libs.nashorn/external/asm-all-4.0.jar
+nashorn.prepend=${basedir}/../libs.nashorn/external/com.oracle.js.parser-ba7a8bc42268.jar
+bootclasspath.prepend=${nashorn.prepend}


### PR DESCRIPTION
- Fix nashorn.prepend and bootclasspath.prepend of project.properties
- Add libs.nashorn as test dependency